### PR TITLE
Fix syntax

### DIFF
--- a/latex/english/pcasm2.tex
+++ b/latex/english/pcasm2.tex
@@ -267,13 +267,14 @@ int b = (int) schar;     /* b = -1  (0xFFFFFFFF) */
 \label{fig:charExt}
 \end{figure}
 
+\begin{samepage}
 There is a common C programming bug that directly relates to this subject.
 Consider the code in Figure~\ref{fig:IObug}. The prototype of 
-{\code fgetc()}{\samepage is:
+{\code fgetc()} is:
 \begin{CodeQuote}
 int fgetc( FILE * );
 \end{CodeQuote}
-One might question }why does the function return back an {\code int}
+One might question why does the function return back an {\code int}
 since it reads characters? The reason is that it normally does return
 back an {\code char} (extended to an {\code int} value using zero
 extension). However, there is one value that it may return that is not
@@ -282,6 +283,7 @@ $-1$. Thus, {\code fgetc()} either returns back a {\code char}
 extended to an {\code int} value (which looks like {\code 000000{\em
 xx}} in hex) or {\code EOF} (which looks like {\code FFFFFFFF} in
 hex).
+\end{samepage}
 
 \begin{figure}[t]
 \begin{lstlisting}[stepnumber=0,frame=tlrb]{}
@@ -519,7 +521,7 @@ _asm_main:
 \end{AsmCodeListing}
 \index{math.asm|)}
 
-\subsection{Extended precision arithmetic \label{sec:ExtPrecArith} \index{integer!extended precision|(}}}
+\subsection{Extended precision arithmetic \label{sec:ExtPrecArith} \index{integer!extended precision|(}}
 
 Assembly language also provides instructions that allow one to perform
 addition and subtraction of numbers larger than double words. These

--- a/latex/english/pcasmf.tex
+++ b/latex/english/pcasmf.tex
@@ -2,7 +2,7 @@
 %front matter of pcasm book
 
 \chapter*{Preface}
-\markboth{\MakeUppercase{Preface}}{} % Clear running headers
+\markboth{\MakeUppercase{Preface}}{}
 \addcontentsline{toc}{chapter}{Preface}
 
 \section*{Purpose}

--- a/latex/english/pcasmf.tex
+++ b/latex/english/pcasmf.tex
@@ -2,6 +2,8 @@
 %front matter of pcasm book
 
 \chapter*{Preface}
+\markboth{\MakeUppercase{Preface}}{} % Clear running headers
+\addcontentsline{toc}{chapter}{Preface}
 
 \section*{Purpose}
 

--- a/latex/english/pcasmf.tex
+++ b/latex/english/pcasmf.tex
@@ -1,7 +1,7 @@
 % -*-LaTex-*-
 %front matter of pcasm book
 
-\chapter{Preface}
+\chapter*{Preface}
 
 \section*{Purpose}
 


### PR DESCRIPTION
**pcasm2.tex**

pandoc throws an error when the environment `{\samepage }` is used. It has been substituted by `\begin{samepage} ...\end{samepage}` and it covers complete paragraphs.

An unnecessary closing curly bracket `}`  has been removed.

**pcasmf.tex**

\chapter{Preface} was originally numbered, though it was the preface. I think because it was done this way to force it to appear in the table of contents (TOC). Two extra lines has been added to ensure that the chapter can be unnumbered while it appears in the TOC  and keeps the same heading style as other chapters.