### PR TITLE
Extra curly bracket removed

### DIFF
--- a/latex/english/pcasm2.tex
+++ b/latex/english/pcasm2.tex
@@ -519,7 +519,7 @@ _asm_main:
 \end{AsmCodeListing}
 \index{math.asm|)}
 
-\subsection{Extended precision arithmetic \label{sec:ExtPrecArith} \index{integer!extended precision|(}}}
+\subsection{Extended precision arithmetic \label{sec:ExtPrecArith} \index{integer!extended precision|(}}
 
 Assembly language also provides instructions that allow one to perform
 addition and subtraction of numbers larger than double words. These


### PR DESCRIPTION
There was an extra curly bracket ( `}` ) that has been removed.